### PR TITLE
implement checksum from key/value list map calculation, add file checksum cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,8 +428,8 @@ Yet there is no binaries
 - [x] docopts as repeated flags, joined in string
 - [x] pass opts as is if cmd is an array
 - [x] file hashes (checksums)
-- [ ] global checksums (check if some commands use checksum so we can skip its calculation)
-- [ ] multiple checksums in one command (kv)
+- [x] global checksums (check if some commands use checksum so we can skip its calculation)
+- [x] multiple checksums in one command (kv)
 - [x] depends on other commands
 - [x] inherit configs
 - [x] LETS_DEBUG env for debugging logs
@@ -442,7 +442,6 @@ Yet there is no binaries
   - [x] command env
 - [ ] dogfood on ci
 - [x] add version flag to lets
-- [ ] add verbose flag to lets
 - [x] add LETSCLI_OPTION - options as is
 - [x] add all env vars event if no options were passed
 - [ ] BUG - when run git commit, lets complains that no config is found for git

--- a/commands/command/checksum.go
+++ b/commands/command/checksum.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 )
 
+var checkSumCache map[string][]byte = make(map[string][]byte)
+
 // calculate sha1 hash from files content and return hex digest
 func calculateChecksum(patterns []string) (string, error) {
 	// read filenames from patterns
@@ -22,48 +24,98 @@ func calculateChecksum(patterns []string) (string, error) {
 	// sort files list
 	sort.Strings(files)
 	hasher := sha1.New()
+	fileHasher := sha1.New()
 	for _, filename := range files {
-		data, err := ioutil.ReadFile(filename)
-		if err != nil {
-			return "", err
+		if cachedSum, found := checkSumCache[filename]; found {
+			hasher.Write(cachedSum)
+		} else {
+			data, err := ioutil.ReadFile(filename)
+			if err != nil {
+				return "", err
+			}
+			cachedSum = fileHasher.Sum(data)
+			checkSumCache[filename] = cachedSum
+			hasher.Write(cachedSum)
+			fileHasher.Reset()
 		}
-		hasher.Write(data)
+
 	}
 
 	checksum := hasher.Sum(nil)
 	return fmt.Sprintf("%x", checksum), nil
 }
 
-func parseAndValidateChecksum(checksum interface{}, newCmd *Command) error {
-	patterns, ok := checksum.([]interface{})
-	if !ok {
-		return newCommandError(
-			"must be a list of string (files of glob patterns)",
-			newCmd.Name,
-			CHECKSUM,
-			"",
-		)
-	}
-
+func checkSumFromList(cmdName string, patterns []interface{}) (string, error) {
 	var files []string
 	for _, value := range patterns {
 		if value, ok := value.(string); ok {
 			files = append(files, value)
 		} else {
-			return newCommandError(
+			return "", newCommandError(
 				"value of checksum list must be a string",
-				newCmd.Name,
+				cmdName,
 				CHECKSUM,
 				"",
 			)
 		}
 	}
-	// TODO make checksum calculation lazy
 	calcChecksum, err := calculateChecksum(files)
 	if err == nil {
-		newCmd.Checksum = calcChecksum
+		return calcChecksum, nil
 	} else {
-		return fmt.Errorf("failed to calculate checksum: %s", err)
+		return "", err
+	}
+}
+
+// TODO make checksum calculation lazy
+func parseAndValidateChecksum(checksum interface{}, newCmd *Command) error {
+	patternsList, okList := checksum.([]interface{})
+	patternsMap, okMap := checksum.(map[interface{}]interface{})
+	if okList{
+		calcChecksum, err := checkSumFromList(newCmd.Name, patternsList)
+		if err != nil {
+			return fmt.Errorf("failed to calculate checksum: %s", err)
+		} else {
+			newCmd.Checksum = calcChecksum
+		}
+	} else if okMap {
+		hasher := sha1.New()
+		newCmd.ChecksumMap = make(map[string]string)
+		for key, patterns := range patternsMap {
+			key, ok := key.(string)
+			if !ok {
+				return newCommandError(
+					"key of checksum list must be a string",
+					newCmd.Name,
+					CHECKSUM,
+					"",
+				)
+			}
+			patterns, ok := patterns.([]interface{})
+			if !ok {
+				return newCommandError(
+					"value of checksum map must be a list",
+					newCmd.Name,
+					CHECKSUM,
+					"",
+				)
+			}
+			calcChecksum, err := checkSumFromList(newCmd.Name, patterns)
+			if err != nil {
+				return fmt.Errorf("failed to calculate checksum: %s", err)
+			} else {
+				newCmd.ChecksumMap[key] = calcChecksum
+			}
+				hasher.Write([]byte(calcChecksum))
+			}
+		newCmd.Checksum = fmt.Sprintf("%x", hasher.Sum(nil))
+	} else {
+		return newCommandError(
+			"must be a list of string (files of glob patterns) or a map of lists of string",
+			newCmd.Name,
+			CHECKSUM,
+			"",
+		)
 	}
 	return nil
 }

--- a/commands/command/checksum.go
+++ b/commands/command/checksum.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 )
 
-var checkSumCache map[string][]byte = make(map[string][]byte)
+var checksumCache map[string][]byte = make(map[string][]byte)
 
 // calculate sha1 hash from files content and return hex digest
 func calculateChecksum(patterns []string) (string, error) {
@@ -26,7 +26,7 @@ func calculateChecksum(patterns []string) (string, error) {
 	hasher := sha1.New()
 	fileHasher := sha1.New()
 	for _, filename := range files {
-		if cachedSum, found := checkSumCache[filename]; found {
+		if cachedSum, found := checksumCache[filename]; found {
 			hasher.Write(cachedSum)
 		} else {
 			data, err := ioutil.ReadFile(filename)
@@ -34,7 +34,7 @@ func calculateChecksum(patterns []string) (string, error) {
 				return "", err
 			}
 			cachedSum = fileHasher.Sum(data)
-			checkSumCache[filename] = cachedSum
+			checksumCache[filename] = cachedSum
 			hasher.Write(cachedSum)
 			fileHasher.Reset()
 		}
@@ -45,42 +45,24 @@ func calculateChecksum(patterns []string) (string, error) {
 	return fmt.Sprintf("%x", checksum), nil
 }
 
-func checkSumFromList(cmdName string, patterns []interface{}) (string, error) {
-	var files []string
-	for _, value := range patterns {
-		if value, ok := value.(string); ok {
-			files = append(files, value)
-		} else {
-			return "", newCommandError(
-				"value of checksum list must be a string",
-				cmdName,
-				CHECKSUM,
-				"",
-			)
-		}
-	}
-	calcChecksum, err := calculateChecksum(files)
-	if err == nil {
-		return calcChecksum, nil
-	} else {
-		return "", err
-	}
-}
-
-// TODO make checksum calculation lazy
 func parseAndValidateChecksum(checksum interface{}, newCmd *Command) error {
 	patternsList, okList := checksum.([]interface{})
 	patternsMap, okMap := checksum.(map[interface{}]interface{})
-	if okList{
-		calcChecksum, err := checkSumFromList(newCmd.Name, patternsList)
-		if err != nil {
-			return fmt.Errorf("failed to calculate checksum: %s", err)
-		} else {
-			newCmd.Checksum = calcChecksum
+	checksumSource := make(map[string][]string)
+	if okList {
+		for _, value := range patternsList {
+			if value, ok := value.(string); ok {
+				checksumSource[""] = append(checksumSource[""], value)
+			} else {
+				return newCommandError(
+					"value of checksum list must be a string",
+					newCmd.Name,
+					CHECKSUM,
+					"",
+				)
+			}
 		}
 	} else if okMap {
-		hasher := sha1.New()
-		newCmd.ChecksumMap = make(map[string]string)
 		for key, patterns := range patternsMap {
 			key, ok := key.(string)
 			if !ok {
@@ -100,15 +82,19 @@ func parseAndValidateChecksum(checksum interface{}, newCmd *Command) error {
 					"",
 				)
 			}
-			calcChecksum, err := checkSumFromList(newCmd.Name, patterns)
-			if err != nil {
-				return fmt.Errorf("failed to calculate checksum: %s", err)
-			} else {
-				newCmd.ChecksumMap[key] = calcChecksum
+			for _, value := range patterns {
+				if value, ok := value.(string); ok {
+					checksumSource[key] = append(checksumSource[key], value)
+				} else {
+					return newCommandError(
+						"value of checksum list must be a string",
+						newCmd.Name,
+						CHECKSUM,
+						"",
+					)
+				}
 			}
-				hasher.Write([]byte(calcChecksum))
-			}
-		newCmd.Checksum = fmt.Sprintf("%x", hasher.Sum(nil))
+		}
 	} else {
 		return newCommandError(
 			"must be a list of string (files of glob patterns) or a map of lists of string",
@@ -117,5 +103,25 @@ func parseAndValidateChecksum(checksum interface{}, newCmd *Command) error {
 			"",
 		)
 	}
+	newCmd.ChecksumCalculator = func() error {
+		return calculateChecksumFromSource(newCmd, checksumSource)
+	}
+	return nil
+}
+
+func calculateChecksumFromSource(newCmd *Command, checksumSource map[string][]string) error {
+	newCmd.ChecksumMap = make(map[string]string)
+	hasher := sha1.New()
+	for key, patterns := range checksumSource {
+		calcChecksum, err := calculateChecksum(patterns)
+		if err != nil {
+			return fmt.Errorf("failed to calculate checksum: %s", err)
+		} else {
+			newCmd.ChecksumMap[key] = calcChecksum
+		}
+		hasher.Write([]byte(calcChecksum))
+	}
+	newCmd.Checksum = fmt.Sprintf("%x", hasher.Sum(nil))
+
 	return nil
 }

--- a/commands/command/command.go
+++ b/commands/command/command.go
@@ -26,16 +26,17 @@ var validFields = strings.Join([]string{
 }, " ")
 
 type Command struct {
-	Name        string
-	Cmd         string
-	Description string
-	Env         map[string]string
-	RawOptions  string
-	Options     map[string]string
-	CliOptions  map[string]string
-	Depends     []string
-	Checksum    string
-	ChecksumMap map[string]string
+	Name               string
+	Cmd                string
+	Description        string
+	Env                map[string]string
+	RawOptions         string
+	Options            map[string]string
+	CliOptions         map[string]string
+	Depends            []string
+	ChecksumCalculator func() error
+	Checksum           string
+	ChecksumMap        map[string]string
 }
 
 type CommandError struct {

--- a/commands/command/command.go
+++ b/commands/command/command.go
@@ -35,6 +35,7 @@ type Command struct {
 	CliOptions  map[string]string
 	Depends     []string
 	Checksum    string
+	ChecksumMap map[string]string
 }
 
 type CommandError struct {

--- a/commands/run.go
+++ b/commands/run.go
@@ -83,6 +83,14 @@ func runCmd(cmdToRun command.Command, cfg *config.Config, out io.Writer, parentN
 		cmdToRun.CliOptions = command.OptsToLetsCli(opts)
 	}
 
+	//calculate checksum if needed
+	if cmdToRun.ChecksumCalculator != nil {
+		err := cmdToRun.ChecksumCalculator()
+		if err != nil {
+			return err
+		}
+	}
+
 	// setup env for command
 	cmd.Env = composeEnvs(
 		os.Environ(),

--- a/commands/run.go
+++ b/commands/run.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 const (
@@ -35,6 +36,14 @@ func convertEnvMapToList(envMap map[string]string) []string {
 
 func convertChecksumToEnvForCmd(checksum string) []string {
 	return []string{fmt.Sprintf("LETS_CHECKSUM=%s", checksum)}
+}
+
+func convertChecksumMapToEnvForCmd(checksumMap map[string]string) []string {
+	var envList []string
+	for name, value := range checksumMap {
+		envList = append(envList, fmt.Sprintf("LETS_CHECKSUM_%s=%s", strings.ToUpper(name), value))
+	}
+	return envList
 }
 
 func composeEnvs(envs ...[]string) []string {
@@ -82,6 +91,7 @@ func runCmd(cmdToRun command.Command, cfg *config.Config, out io.Writer, parentN
 		convertEnvMapToList(cmdToRun.Options),
 		convertEnvMapToList(cmdToRun.CliOptions),
 		convertChecksumToEnvForCmd(cmdToRun.Checksum),
+		convertChecksumMapToEnvForCmd(cmdToRun.ChecksumMap),
 	)
 	if !isChildCmd {
 		logging.Log.Debugf(

--- a/config/config.go
+++ b/config/config.go
@@ -277,7 +277,6 @@ func (c *Config) loadCommands(cmds map[interface{}]interface{}) error {
 	for key, value := range cmds {
 		keyStr := key.(string)
 		newCmd := command.NewCommand(keyStr)
-
 		err := command.ParseAndValidateCommand(&newCmd, value.(map[interface{}]interface{}))
 		if err != nil {
 			return err

--- a/lets-test.yaml
+++ b/lets-test.yaml
@@ -55,3 +55,15 @@ commands:
     cmd:
       - echo
       - "${LETS_CHECKSUM}"
+
+  test-checksum-map:
+    description: test checksum
+    checksum:
+      compose:
+        - docker-compose
+      misc:
+        - README.md
+        - LICENSE
+    cmd:
+      - echo
+      - "${LETS_CHECKSUM} ${LETS_CHECKSUM_COMPOSE} ${LETS_CHECKSUM_MISC}"


### PR DESCRIPTION
If checksum is map then total checksum is available as ${LETS_CHECKSUM} and checksum for each key is exposed as ${LETS_CHECKSUM_<KEY>}.
Checksum for each file is cached so the first one to calculate will put the checksum under filename key into the cache.
